### PR TITLE
1 add fake data to the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ npm-debug.*
 web-build/
 .pnpm-store/
 *.env
+*.orig
 
 # macOS
 .DS_Store

--- a/db/fakeData.sql
+++ b/db/fakeData.sql
@@ -1,0 +1,11 @@
+-- Fake users
+INSERT INTO users (first_name, last_name, phone, email, password)
+    VALUES ('taylor', 'poulsen', '2081234567', 'tp@gmail.com', 'secret');
+
+INSERT INTO users (first_name, last_name, phone, email, password)
+    VALUES ('trevor', 'cooper', '2082345678', 'tc@gmail.com', 'secret');
+
+
+-- Fake businesses
+INSERT INTO businesses (name, address, phone)
+    VALUES ('Fake Business', '1234 W Fake St.', '2083456789')

--- a/scripts/configureDevTools.sh
+++ b/scripts/configureDevTools.sh
@@ -41,3 +41,8 @@ didSucceed
 
 echo "Creating tables..."
 psql -f db/schema.sql
+didSucceed
+
+echo "Creating fake data..."
+psql -f db/fakeData.sql
+didSucceed


### PR DESCRIPTION
closes #1 

to verify that it worked, check out this branch and then:
- from within vscode, do ctrl+shift-p and select "rebuild dev container"
    - it may fail on the first attempt, just hit "retry" and it should work on the second attempt, this is something we might want to fix at some point
- after the dev container is done rebuilding, use the vscode terminal to start a psql session within the dev container
    - ctrl+~ to open the vscode terminal
    - `psql` to start a psql session
    - `\d` to describe all the tables
    - `select * from <table name>;` to print some of the fake data
        - for now the only "table name"s that have any data are `users` and `businesses` so use both of those
    - the statement should print a table showing the db output with the fake data we added to it.